### PR TITLE
Potential fix for code scanning alert no. 481: Database query built from user-controlled sources

### DIFF
--- a/app/api-server.js
+++ b/app/api-server.js
@@ -65,10 +65,14 @@ MongoClient.connect(mongo_url, { useNewUrlParser: true }, (err, client) => {
 })
 
 function api_authenticate(user, pass, req, res) {
+	if (typeof user !== 'string' || typeof pass !== 'string') {
+		res.status(400).json({ "message": "Invalid input types" });
+		return;
+	}
 	console.log('>>> Logging user ' + user + ' with password: ' + pass);
 	const users = db.collection('users');
 
-	users.findOne({ email: user, password: pass }, function (err, result) {
+	users.findOne({ email: { $eq: user }, password: { $eq: pass } }, function (err, result) {
 		if (err) {
 			console.log('>>> Query error...' + err);
 			res.status(500).json({ "message": "system error" });


### PR DESCRIPTION
Potential fix for [https://github.com/burrito-party/api_tester/security/code-scanning/481](https://github.com/burrito-party/api_tester/security/code-scanning/481)

To fix the issue, we need to ensure that the user-provided values (`user` and `pass`) are treated as literal values in the MongoDB query. This can be achieved by:
1. Using the `$eq` operator in the query to explicitly compare the values as literals.
2. Validating the input to ensure that `user` and `pass` are strings and do not contain any unexpected data types or structures.

The fix involves modifying the query on line 71 to use the `$eq` operator and adding input validation for `user` and `pass` in the `api_authenticate` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
