### PR TITLE
Potential fix for code scanning alert no. 485: Incomplete string escaping or encoding

### DIFF
--- a/app/public/js/angular-route.js
+++ b/app/public/js/angular-route.js
@@ -292,6 +292,7 @@ function $RouteProvider() {
         keys = ret.keys = [];
 
     path = path
+      .replace(/\\/g, '\\\\') // Escape backslashes
       .replace(/([().])/g, '\\$1')
       .replace(/(\/)?:(\w+)(\*\?|[?*])?/g, function(_, slash, key, option) {
         var optional = (option === '?' || option === '*?') ? '?' : null;


### PR DESCRIPTION
Potential fix for [https://github.com/burrito-party/api_tester/security/code-scanning/485](https://github.com/burrito-party/api_tester/security/code-scanning/485)

To fix the issue, we need to ensure that backslashes in the `path` string are properly escaped before constructing the regular expression. This can be achieved by adding an additional `.replace` call to escape backslashes (`\`) by replacing them with double backslashes (`\\`). This ensures that any backslashes in the input are treated as literal characters in the regular expression.

The fix involves modifying the `path` string processing logic on line 294 to include a `.replace` call for backslashes. No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
